### PR TITLE
lighten footer of tables so team rows are delineated from last player

### DIFF
--- a/public/css/yasp.css
+++ b/public/css/yasp.css
@@ -359,6 +359,13 @@ td.text-left {
     text-align: left;
 }
 
+
+/* lighten footer of tables so radiant/dire rows are delineated from last player */
+tfoot tr {
+    background-color: #3d3d3d;
+}
+
+
 /* Use sans-serif on tables*/
 
 


### PR DESCRIPTION
To make last player row easier to read, as well as the aggregates
